### PR TITLE
feat(credentials): add gemini provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ repo/
 
 #### 資格情報の設定
 
-LLM 連携を行う場合は、以下の手順で OpenAI API Key を登録します。
+LLM 連携を行う場合は、以下の手順で OpenAI / Google Gemini いずれか（または両方）の API Key を登録します。
 
 1. `config/credentials.example.json` をコピーして `config/credentials.json` を作成。
-2. `"llm.openai_api_key"` に実際のキーを設定。
-3. CI や別環境でファイルパスを切り替える場合は、環境変数 `AUTOEDA_CREDENTIALS_FILE` で JSON のパスを指定。
+2. `"llm.provider"` に既定で使用したいプロバイダ（`"openai"` または `"gemini"`）を設定。
+3. `"llm.openai.api_key"` や `"llm.gemini.api_key"` に実際のキーを設定（どちらか一方でも可、両方を保存しておくと UI で簡単に切り替え可能）。
+4. CI や別環境でファイルパスを切り替える場合は、環境変数 `AUTOEDA_CREDENTIALS_FILE` で JSON のパスを指定。
 
 ```bash
 cp config/credentials.example.json config/credentials.json
@@ -59,10 +60,12 @@ $EDITOR config/credentials.json  # <REPLACE_WITH_REAL_KEY> を更新
 `config/credentials.json` は `.gitignore` に登録済みのため、実際のキーをコミットする心配はありません（リポジトリ外へ持ち出す場合は手動で保護してください）。
 
 ```jsonc
-// config/credentials.json の最小構成例
+// config/credentials.json の例
 {
   "llm": {
-    "openai_api_key": "sk-..."
+    "provider": "openai",
+    "openai": { "api_key": "sk-..." },
+    "gemini": { "api_key": "gm-..." }
   }
 }
 ```
@@ -71,7 +74,7 @@ $EDITOR config/credentials.json  # <REPLACE_WITH_REAL_KEY> を更新
 
 ```bash
 # 例: GitHub Actions で secrets から生成する場合
-echo "${{ secrets.AUTOEDA_OPENAI_KEY_JSON }}" > $RUNNER_TEMP/autoeda_credentials.json
+echo "${{ secrets.AUTOEDA_LLM_CREDENTIALS_JSON }}" > $RUNNER_TEMP/autoeda_credentials.json
 export AUTOEDA_CREDENTIALS_FILE="$RUNNER_TEMP/autoeda_credentials.json"
 python -m pytest tests/python
 ```
@@ -126,7 +129,7 @@ uvicorn main:app --reload
 
 ブラウザで http://localhost:5173 を開き、サイドメニューからストーリー別の画面を操作できます。UI 上のリクエストは `VITE_API_BASE` で指定した API に送信されます（未設定の場合は同一オリジンに送信されるため注意）。
 
-OpenAI API Key は http://localhost:5173/settings の「Settings」画面から入力して登録することもできます（内部的には `config/credentials.json` に保存されます）。ローカルでの初回セットアップ時はこの画面を利用すると差し替えが容易です。
+LLM プロバイダ／API Key は http://localhost:5173/settings の「Settings」画面から登録・切り替えできます（内部的には `config/credentials.json` に保存されます）。ローカルでの初回セットアップ時はこの画面を利用すると差し替えが容易です。
 
 ### テストスイート
 

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -4,5 +4,6 @@ httpx==0.27.2
 python-multipart==0.0.9
 chromadb==0.5.5
 tiktoken==0.7.0
+google-generativeai==0.7.2
 pytest==8.3.2
 pytest-mock==3.14.0

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,29 +1,46 @@
-import React, { useEffect, useState } from 'react';
-import { getLlmCredentialStatus, setOpenAIApiKey } from '@autoeda/client-sdk';
+import React, { useCallback, useEffect, useState } from 'react';
+import { getLlmCredentialStatus, setLlmCredentials, type LlmProvider } from '@autoeda/client-sdk';
+
+const PROVIDER_LABELS: Record<LlmProvider, string> = {
+  openai: 'OpenAI',
+  gemini: 'Gemini',
+};
 
 export function SettingsPage(): JSX.Element {
+  const [activeProvider, setActiveProvider] = useState<LlmProvider>('openai');
   const [configured, setConfigured] = useState<boolean | null>(null);
+  const [providerStates, setProviderStates] = useState<Record<LlmProvider, boolean>>({
+    openai: false,
+    gemini: false,
+  });
   const [apiKey, setApiKey] = useState('');
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        const status = await getLlmCredentialStatus();
-        if (mounted) {
-          setConfigured(Boolean(status?.configured));
-        }
-      } catch {
-        if (mounted) setConfigured(false);
-      }
-    })();
-    return () => {
-      mounted = false;
-    };
+  const loadStatus = useCallback(async () => {
+    try {
+      const status = await getLlmCredentialStatus();
+      const providers = status.providers ?? {
+        openai: { configured: false },
+        gemini: { configured: false },
+      };
+      setActiveProvider(status.provider);
+      setConfigured(Boolean(status.configured));
+      setProviderStates({
+        openai: providers.openai.configured,
+        gemini: providers.gemini.configured,
+      });
+    } catch {
+      setConfigured(false);
+      setActiveProvider('openai');
+      setProviderStates({ openai: false, gemini: false });
+    }
   }, []);
+
+  useEffect(() => {
+    loadStatus();
+  }, [loadStatus]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -36,10 +53,10 @@ export function SettingsPage(): JSX.Element {
     setMessage(null);
     setError(null);
     try {
-      await setOpenAIApiKey(apiKey.trim());
-      setConfigured(true);
-      setMessage('設定が更新されました');
+      await setLlmCredentials(activeProvider, apiKey.trim());
       setApiKey('');
+      await loadStatus();
+      setMessage('設定が更新されました');
     } catch (err) {
       const detail = err instanceof Error ? err.message : '更新に失敗しました';
       setError(detail);
@@ -51,24 +68,46 @@ export function SettingsPage(): JSX.Element {
   const statusLabel = configured === null ? '読み込み中' : configured ? '設定済み' : '未設定';
 
   return (
-    <section style={{ maxWidth: 520 }}>
+    <section style={{ maxWidth: 560 }}>
       <h1 style={{ fontSize: 24, fontWeight: 600, marginBottom: 16 }}>システム設定</h1>
-      <p style={{ marginBottom: 8 }}>現在の状態: {statusLabel}</p>
-      <p style={{ marginBottom: 24, color: '#4b5563' }}>
-        OpenAI API Key は暗号化せずローカルファイル (`config/credentials.json`) に保存されます。共有リポジトリには含まれません。
+      <p style={{ marginBottom: 8 }}>現在の状態: {statusLabel}（使用中: {PROVIDER_LABELS[activeProvider]}）</p>
+      <p style={{ marginBottom: 16, color: '#4b5563' }}>
+        LLM の API Key はローカルファイル (`config/credentials.json`) に保存され、リポジトリには含まれません。
       </p>
-      <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 12 }}>
-        <label htmlFor="openai-key" style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <span>OpenAI API Key</span>
+      <div style={{ marginBottom: 20, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+        <h2 style={{ marginTop: 0, marginBottom: 8, fontSize: 16 }}>プロバイダ別ステータス</h2>
+        <ul style={{ margin: 0, paddingLeft: 16 }}>
+          {Object.entries(providerStates).map(([provider, state]) => (
+            <li key={provider}>
+              {PROVIDER_LABELS[provider as LlmProvider]} — {state ? '設定済み' : '未設定'}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 16 }}>
+        <label htmlFor="provider-select" style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span>使用する LLM プロバイダ</span>
+          <select
+            id="provider-select"
+            value={activeProvider}
+            onChange={(event) => setActiveProvider(event.target.value as LlmProvider)}
+            style={{ padding: '8px 12px', border: '1px solid #d1d5db', borderRadius: 4 }}
+          >
+            <option value="openai">OpenAI</option>
+            <option value="gemini">Google Gemini</option>
+          </select>
+        </label>
+        <label htmlFor="llm-key" style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span>{PROVIDER_LABELS[activeProvider]} API Key</span>
           <input
-            id="openai-key"
+            id="llm-key"
             type="password"
             value={apiKey}
             onChange={(event) => setApiKey(event.target.value)}
-            placeholder="sk-..."
+            placeholder={activeProvider === 'openai' ? 'sk-...' : 'gm-...'}
             autoComplete="off"
             style={{ padding: '8px 12px', border: '1px solid #d1d5db', borderRadius: 4 }}
-            aria-label="OpenAI API Key"
+            aria-label={`${PROVIDER_LABELS[activeProvider]} API Key`}
           />
         </label>
         <button

--- a/apps/web/src/tests/msw/handlers.ts
+++ b/apps/web/src/tests/msw/handlers.ts
@@ -123,4 +123,15 @@ export const handlers = [
       measured_summary: { rows: 100, cols: 5, missing_rate: 0.1 },
     });
   }),
+  http.get('/api/credentials/llm', async () =>
+    HttpResponse.json({
+      provider: 'openai',
+      configured: false,
+      providers: {
+        openai: { configured: false },
+        gemini: { configured: false },
+      },
+    }),
+  ),
+  http.post('/api/credentials/llm', async () => new HttpResponse(null, { status: 204 })),
 ];

--- a/apps/web/src/tests/unit/settingsPage.test.tsx
+++ b/apps/web/src/tests/unit/settingsPage.test.tsx
@@ -4,14 +4,14 @@ import React from 'react';
 
 vi.mock('@autoeda/client-sdk', () => ({
   getLlmCredentialStatus: vi.fn(),
-  setOpenAIApiKey: vi.fn(),
+  setLlmCredentials: vi.fn(),
 }));
 
 import { SettingsPage } from '../../pages/SettingsPage';
-import { getLlmCredentialStatus, setOpenAIApiKey } from '@autoeda/client-sdk';
+import { getLlmCredentialStatus, setLlmCredentials } from '@autoeda/client-sdk';
 
 const mockedGetStatus = getLlmCredentialStatus as unknown as MockedFunction<typeof getLlmCredentialStatus>;
-const mockedSetKey = setOpenAIApiKey as unknown as MockedFunction<typeof setOpenAIApiKey>;
+const mockedSetKey = setLlmCredentials as unknown as MockedFunction<typeof setLlmCredentials>;
 
 describe('SettingsPage', () => {
   beforeEach(() => {
@@ -20,27 +20,54 @@ describe('SettingsPage', () => {
   });
 
   it('表示時に現在の設定状態を読み込む', async () => {
-    mockedGetStatus.mockResolvedValue({ configured: false });
+    mockedGetStatus.mockResolvedValue({
+      provider: 'openai',
+      configured: false,
+      providers: {
+        openai: { configured: false },
+        gemini: { configured: false },
+      },
+    });
     render(<SettingsPage />);
 
-    expect(await screen.findByText('現在の状態: 未設定')).toBeTruthy();
+    expect(await screen.findByText(/現在の状態: 未設定/)).toBeTruthy();
+    expect(await screen.findByText('OpenAI — 未設定')).toBeTruthy();
+    expect(await screen.findByText('Gemini — 未設定')).toBeTruthy();
   });
 
   it('APIキーを送信すると設定済みに更新される', async () => {
-    mockedGetStatus.mockResolvedValue({ configured: false });
+    mockedGetStatus.mockResolvedValueOnce({
+      provider: 'openai',
+      configured: false,
+      providers: {
+        openai: { configured: false },
+        gemini: { configured: false },
+      },
+    });
+    mockedGetStatus.mockResolvedValueOnce({
+      provider: 'gemini',
+      configured: true,
+      providers: {
+        openai: { configured: false },
+        gemini: { configured: true },
+      },
+    });
     mockedSetKey.mockResolvedValue();
 
     render(<SettingsPage />);
 
-    const input = await screen.findByLabelText('OpenAI API Key');
-    fireEvent.change(input, { target: { value: 'sk-test-abc123456789' } });
+    const providerSelect = await screen.findByLabelText(/使用する LLM プロバイダ/);
+    fireEvent.change(providerSelect, { target: { value: 'gemini' } });
+
+    const input = await screen.findByLabelText('Gemini API Key');
+    fireEvent.change(input, { target: { value: 'gm-test-abc123456789' } });
     fireEvent.submit(input.closest('form')!);
 
     await waitFor(() => {
-      expect(mockedSetKey).toHaveBeenCalledWith('sk-test-abc123456789');
+      expect(mockedSetKey).toHaveBeenCalledWith('gemini', 'gm-test-abc123456789');
     });
 
     expect(await screen.findByText('設定が更新されました')).toBeTruthy();
-    expect(await screen.findByText('現在の状態: 設定済み')).toBeTruthy();
+    expect(await screen.findByText(/現在の状態: 設定済み/)).toBeTruthy();
   });
 });

--- a/config/credentials.example.json
+++ b/config/credentials.example.json
@@ -1,5 +1,11 @@
 {
   "llm": {
-    "openai_api_key": "<REPLACE_WITH_REAL_KEY>"
+    "provider": "openai",
+    "openai": {
+      "api_key": "<REPLACE_WITH_OPENAI_KEY>"
+    },
+    "gemini": {
+      "api_key": "<OPTIONAL_REPLACE_WITH_GEMINI_KEY>"
+    }
   }
 }


### PR DESCRIPTION
### 変更点
- LLM 資格情報ストアと API を拡張し、OpenAI/Gemini 両プロバイダを設定・切替できるようにしました。
- オーケストレーション層でアクティブプロバイダを読み、Gemini（google-generativeai）呼び出しを追加。
- Settings UI / SDK / README を更新し、プロバイダ別ステータス表示とキー更新を対応。
- Pytest / Vitest / ESLint を実行し、Gemini 経路のユニットテストを追加。

### テスト
- python -m pytest tests/python
- npm run -w @autoeda/web lint
- npm run -w @autoeda/web test -- --run

### CI
- https://github.com/youkawa/AutoEDA/actions/runs/17812115871
