### PR TITLE
fix(api,rag,web): harden RAG init, Gemini safety, StrictMode dedupe

### DIFF
--- a/apps/api/services/rag.py
+++ b/apps/api/services/rag.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import os
 from pathlib import Path
+import threading
 from typing import Any, Dict, Iterable, List, Optional
 
 from apps.api import config
@@ -26,43 +27,72 @@ except ImportError:  # pragma: no cover
     OpenAI = None  # type: ignore
 
 _DATA_DIR = Path("data/rag")
-_DEFAULT_COLLECTION = "autoeda_corpus"
+_DEFAULT_COLLECTION = os.getenv("AUTOEDA_RAG_COLLECTION", "autoeda_corpus")
 
 _in_memory_store: List[Dict[str, Any]] = []
 _chroma_client = None
 _collection = None
 _embedding_fn = None
+_init_lock = threading.Lock()
 
 
 def _ensure_chroma() -> Optional[Any]:
+    """Chroma の初期化をスレッド安全に実行する。
+
+    - PersistentClient は telemetry を無効化（ノイズ抑止）
+    - コレクション作成は競合時に get_collection フォールバック
+    """
     global _chroma_client, _collection, _embedding_fn
     if chromadb is None:
         return None
-    if _chroma_client is None:
-        _DATA_DIR.mkdir(parents=True, exist_ok=True)
-        _chroma_client = chromadb.PersistentClient(path=str(_DATA_DIR))
-    if _embedding_fn is None:
-        try:
-            api_key = config.get_openai_api_key()
-        except config.CredentialsError:
-            api_key = None
-        if api_key and embedding_functions is not None:
+
+    with _init_lock:
+        if _chroma_client is None:
+            _DATA_DIR.mkdir(parents=True, exist_ok=True)
             try:
-                _embedding_fn = embedding_functions.OpenAIEmbeddingFunction(
-                    api_key=api_key,
-                    model_name=os.getenv("AUTOEDA_EMBEDDING_MODEL", "text-embedding-3-small"),
+                from chromadb.config import Settings  # type: ignore
+                settings = Settings(anonymized_telemetry=False)
+            except Exception:  # pragma: no cover - 古いバージョン互換
+                settings = None  # type: ignore
+            if settings is not None:
+                _chroma_client = chromadb.PersistentClient(path=str(_DATA_DIR), settings=settings)
+            else:
+                _chroma_client = chromadb.PersistentClient(path=str(_DATA_DIR))
+
+        if _embedding_fn is None:
+            try:
+                api_key = config.get_openai_api_key()
+            except config.CredentialsError:
+                api_key = None
+            if api_key and embedding_functions is not None:
+                try:
+                    _embedding_fn = embedding_functions.OpenAIEmbeddingFunction(
+                        api_key=api_key,
+                        model_name=os.getenv("AUTOEDA_EMBEDDING_MODEL", "text-embedding-3-small"),
+                    )
+                except Exception:
+                    # openai パッケージ未インストールなど、埋め込み利用不可 → フォールバック
+                    return None
+            else:
+                return None
+
+        if _collection is None:
+            try:
+                _collection = _chroma_client.get_or_create_collection(
+                    name=_DEFAULT_COLLECTION,
+                    embedding_function=_embedding_fn,
                 )
             except Exception:
-                # openai パッケージ未インストールなど、埋め込み利用不可 → フォールバック
-                return None
-        else:
-            return None
-    if _collection is None:
-        _collection = _chroma_client.get_or_create_collection(
-            name=_DEFAULT_COLLECTION,
-            embedding_function=_embedding_fn,
-        )
-    return _collection
+                # 競合（UniqueConstraint 等）時は既存コレクションを取得
+                try:
+                    _collection = _chroma_client.get_collection(
+                        name=_DEFAULT_COLLECTION,
+                        embedding_function=_embedding_fn,
+                    )
+                except Exception:
+                    return None
+
+        return _collection
 
 
 def ingest(documents: Iterable[Dict[str, Any]]) -> None:


### PR DESCRIPTION
### 目的
- RAG/Chroma 初期化競合による 500 を解消し、ログノイズを抑制
- Gemini 応答ブロック時の理由提示（safety_ratings）
- React StrictMode 下の EDA API 二重呼び出しのデデュープ
- RAG コレクション名の環境変数化（並列/CI分離）

### 変更点
- api/orchestrator: RAG シードをロック、Gemini safety を人間可読化
- api/rag: Chroma 初期化を逐次化、telemetry 無効、コレクション名 env (`AUTOEDA_RAG_COLLECTION`)
- web/EdaPage: 同一 datasetId のリクエストをページ内でデデュープ

### 検証
- `uvicorn apps.api.main:app --reload` 起動下で `http://localhost:5173/eda/ds_001` を複数回リロード
  - UniqueConstraintError/telemetry エラーが出ない
  - 500 が消失
- Gemini ブロック誘発時、API 側評価ログにブロックカテゴリ表示

### 影響範囲
- RAG（Chroma/Embedding）、EDA ページ初期表示、LLM エラー文言

### セキュリティ
- Secrets 取扱いの変更なし

### CI
- 通常どおり web/api ワークフロー実行。必要に応じて main の必須チェックに登録してください。